### PR TITLE
Permit installation of zend-diactoros 2.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 	"require": {
 		"php": ">=5.6",
 		"mcustiel/creature": "^2.0.0",
-		"zendframework/zend-diactoros": "^1.1.3",
+		"zendframework/zend-diactoros": "^1.1.3 || ^2.0",
 		"mcustiel/mockable-datetime": "^1.0.0"
 	},
 	"require-dev": {


### PR DESCRIPTION
Currently using Phiremock prevents us from updating to zend-diactoros 2.1.

Please permit installation of `zendframework/zend-diactoros` as version `^2.0`.

Test suite seems happy on Php 7.3.